### PR TITLE
fix: bump version number from `0.4.3` to `0.4.4`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@neynar/react",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neynar/react",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.24.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neynar/react",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Farcaster frontend component library powered by Neynar",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",


### PR DESCRIPTION
fixes build errors by bumping the version number of the package from `0.4.3` to `0.4.4` (which is necessary anyways & I overlooked with the last PR)