### PR TITLE
fix: ensure a cast embed link matches system theme text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neynar/react",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Farcaster frontend component library powered by Neynar",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/src/components/organisms/NeynarCastCard/hooks/useRenderEmbeds.tsx
+++ b/src/components/organisms/NeynarCastCard/hooks/useRenderEmbeds.tsx
@@ -1,12 +1,19 @@
 import React from 'react';
 import { METADATA_PROXY_URL, NEYNAR_API_URL } from '../../../../constants';
 import { NeynarCastCard } from '..';
+import { styled } from '@pigment-css/react';
 
 type OpenGraphData = {
   'og:image'?: string;
   'og:title'?: string;
   'og:description'?: string;
 };
+
+const StyledLink = styled.a(({ theme }) => ({
+  textDecoration: "underline",
+  color: theme.vars.palette.text,
+  overflowWrap: 'break-word',
+}));
 
 async function fetchOpenGraphData(url: string): Promise<{ ogImage: string, ogTitle: string, ogDescription: string }> {
   try {
@@ -121,9 +128,9 @@ export const useRenderEmbeds = (embeds: Embed[], viewerFid?: number): React.Reac
                 boxSizing: 'border-box',
               }}>
                 {ogImage && <img src={ogImage} alt={ogTitle} style={{ marginRight: '10px', height: '100%', width: '100px', objectFit: 'cover', borderRadius: '5px' }} />}
-                <a href={embed.url} target="_blank" rel="noreferrer" style={{ overflowWrap: 'break-word', color: 'white', textDecoration: 'underline' }}>
+                <StyledLink href={embed.url} target="_blank" rel="noreferrer">
                   {ogTitle || embed.url}
-                </a>
+                </StyledLink>
               </div>
             );
           }


### PR DESCRIPTION
This fix ensures that an embed url in a cast matches the system's text color

The first picture below showed what the component looked like in light mode(the text was white so it's not visible) and the second picture shows the component after the fix, where the text dynamically changes in light & dark mode.

<img width="688" alt="Cast with Image and Link before fix" src="https://github.com/neynarxyz/react/assets/12853808/15b034db-57ba-41e6-bf48-b07e7eb4b53b">

<img width="561" alt="Cast with Image and Link after fix" src="https://github.com/neynarxyz/react/assets/12853808/da5c0b6c-2e1c-425b-a937-001a450cd7ec">

