### PR TITLE
fix: make sure `useLinkifyBio` doesn't pick up other `/` instances

### DIFF
--- a/src/components/organisms/NeynarProfileCard/hooks/useLinkifyBio.tsx
+++ b/src/components/organisms/NeynarProfileCard/hooks/useLinkifyBio.tsx
@@ -3,7 +3,7 @@ import { styled } from "@pigment-css/react";
 
 const WARPCAST_DOMAIN = "https://warpcast.com";
 
-const channelRegex = /\/\w+/g;
+const channelRegex = /(^|\s)\/\w+/g;
 const mentionRegex = /@\w+/g;
 const urlRegex = /((https?:\/\/)?([a-zA-Z0-9.-]+\.[a-zA-Z]{2,})(\/[^\s]*)?)/g;
 const combinedRegex = new RegExp(
@@ -13,7 +13,7 @@ const combinedRegex = new RegExp(
 
 const generateUrl = (match: string): string => {
   if (channelRegex.test(match)) {
-    return `${WARPCAST_DOMAIN}/~/channel${match}`;
+    return `${WARPCAST_DOMAIN}/~/channel${match.trim()}`;
   } else if (mentionRegex.test(match)) {
     return `${WARPCAST_DOMAIN}/${match.substring(1)}`;
   } else if (urlRegex.test(match)) {
@@ -41,7 +41,7 @@ export const useLinkifyBio = (text: string): React.ReactNode[] => {
     const url = generateUrl(match[0]);
     elements.push(
       <StyledLink key={matchIndex} href={url} target="_blank">
-        {match[0]}
+        {match[0].trim()}
       </StyledLink>
     );
 


### PR DESCRIPTION
cleans up `useLinkifyBio` to ensure that mentions of `/` that don't match the channels/URLs regex aren't highlighted
(first screenshot is before the changes and second screenshot is after the changes)

<img width="701" alt="before" src="https://github.com/neynarxyz/react/assets/12853808/3b3814e4-900c-411c-8c7c-de6566f16b9b">

![after](https://github.com/neynarxyz/react/assets/12853808/3ff67486-b881-4425-8bcf-b1cbd4df3b85)
