### PR TITLE
call on auth success on initial load

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ test-sdk.ts
 .env.local
 .env.development
 .evn.production
+storybook-static
+yarn.lock

--- a/src/contexts/AuthContextProvider.tsx
+++ b/src/contexts/AuthContextProvider.tsx
@@ -57,6 +57,7 @@ export const AuthContextProvider: React.FC<AuthContextProviderProps> = ({
     if (neynarAuthenticatedUser) {
       setUser(neynarAuthenticatedUser);
       setIsAuthenticated(true);
+      onAuthSuccess({ user: neynarAuthenticatedUser });
     } else {
       setUser(null);
       setIsAuthenticated(false);


### PR DESCRIPTION
- make it so on auth success is called on initial load
<img width="633" alt="Screenshot 2024-07-19 at 2 00 36 PM" src="https://github.com/user-attachments/assets/42d6cf30-eaca-44cb-ab47-f6f11ceaed40">

- remove storybook static from git