### PR TITLE
fix: export `CastCard` from the package so devs can pass custom data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neynar/react",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Farcaster frontend component library powered by Neynar",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/src/components/index.tsx
+++ b/src/components/index.tsx
@@ -1,4 +1,5 @@
 export { NeynarAuthButton } from "./organisms/NeynarAuthButton";
+export { CastCard } from "./molecules/CastCard";
 export { NeynarCastCard } from "./organisms/NeynarCastCard"; 
 export { NeynarConversationList } from "./organisms/NeynarConversationList"; 
 export { NeynarFeedList } from "./organisms/NeynarFeedList"; 


### PR DESCRIPTION
allows for developers to replicate the `NeynarCastCard` primary example which takes static JSON data as opposed to a live fetch request
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/50b459ed-7061-474e-a83e-833a5f859d86">
