### PR TITLE
fix: move redirect handlers to the default implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neynar/react",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Farcaster frontend component library powered by Neynar",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/src/components/molecules/FrameCard.tsx
+++ b/src/components/molecules/FrameCard.tsx
@@ -79,18 +79,9 @@ const InputField = styled.input({
 });
 
 function CastFrameBtn({ number, text, actionType, target, frameUrl, handleOnClick }: any) {
-  const handleClick = () => {
-    if (actionType === "link" && target) {
-      window.open(target, "_blank");
-    } else if(actionType === "mint") {
-      window.open(frameUrl, "_blank");
-    } else {
-      handleOnClick(number);
-    }
-  };
 
   return (
-    <FrameButton onClick={handleClick}>
+    <FrameButton onClick={() => handleOnClick(number)}>
       {text}
       {(actionType === "link" || actionType === "post_redirect" || actionType === "mint") && <ExternalLinkIcon />}
     </FrameButton>


### PR DESCRIPTION
moves redirect handlers to the default implementation and ensures it works for `mint`, `link`, and `post_redirect`