### PR TITLE
make video embeds muted by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ test-sdk.ts
 .env
 .env.local
 .env.development
-.evn.production
+.env.production

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neynar/react",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Farcaster frontend component library powered by Neynar",
   "main": "dist/bundle.cjs.js",
   "module": "dist/bundle.es.js",

--- a/src/components/organisms/NeynarCastCard/hooks/useRenderEmbeds.tsx
+++ b/src/components/organisms/NeynarCastCard/hooks/useRenderEmbeds.tsx
@@ -172,6 +172,7 @@ const NativeVideoPlayer: React.FC<NativeVideoPlayerProps> = ({ url }) => {
     <video
       ref={videoRef}
       controls
+      muted={true}
       style={{
         width: 'auto',
         maxWidth: '100%',


### PR DESCRIPTION
- makes video embeds muted by default, the user can reenable the sound with controls
<img width="890" alt="Screenshot 2024-08-26 at 5 41 50 PM" src="https://github.com/user-attachments/assets/95863323-ce81-4d75-a420-4baecfea32d2">
