### PR TITLE
Fix wrong parameters name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,8 +145,8 @@ Usage:
 import { NeynarFeedList } from "@neynar/react";
 
 <NeynarFeedList 
-  feed_type="filter" 
-  filter_type="fids" 
+  feedType="filter" 
+  filterType="fids" 
   fids="2"
   viewerFid={2} 
 />


### PR DESCRIPTION
The parameter name should be feedType and filterType rather than feed_type, filter_type