### PR TITLE
docs: fix typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ import { NeynarFrameCard } from "@neynar/react";
 ```
 
 ## How to securely implement write actions
-There are currently two components that offer props for develoeprs to handle write actions: `NeynarCastCard`(write action handlers for cast reactions) and `NeynarFeedCard`(write action handlers for frame interactions). We highly recommend that you call Neynar's POST APIs(or other intended APIs) from your own, authenticated server to ensure that your Neynar API key credentials are not exposed on the client-side. Check out the [example app](https://github.com/neynarxyz/farcaster-examples/tree/main/wownar-react-sdk) below for a guide and example of securely implementing write actions. 
+There are currently two components that offer props for developers to handle write actions: `NeynarCastCard`(write action handlers for cast reactions) and `NeynarFeedCard`(write action handlers for frame interactions). We highly recommend that you call Neynar's POST APIs(or other intended APIs) from your own, authenticated server to ensure that your Neynar API key credentials are not exposed on the client-side. Check out the [example app](https://github.com/neynarxyz/farcaster-examples/tree/main/wownar-react-sdk) below for a guide and example of securely implementing write actions. 
 
 
 ## Example app


### PR DESCRIPTION
"develoeprs" → "developers"

Fixed a typo to make the document clearer. Hope this fix helps.